### PR TITLE
Make grab compile on OS X

### DIFF
--- a/grab.cc
+++ b/grab.cc
@@ -433,7 +433,7 @@ int main(int argc, char **argv)
 				cerr<<"pthread_create: "<<strerror(r)<<endl;
 				exit(-1);
 			}
-            set_thread_affinity(&tids[i], i);
+			set_thread_affinity(&tids[i], i);
 		}
 
 		for (int i = 0; i < cores; ++i) {


### PR DESCRIPTION
Move all the Linux-dependent stuff (CPU affinity and some fancy mmap(2) flags) to #ifdef blocks.

Remove a couple unused fields.
